### PR TITLE
Connect Adopt a Snail page to API, Edit NavBar

### DIFF
--- a/client/src/components/complex-components/NavBar/NAV_BAR_LINKS.tsx
+++ b/client/src/components/complex-components/NavBar/NAV_BAR_LINKS.tsx
@@ -27,3 +27,10 @@ export const PrototypePages = [
     linkURL: '/search-results',
   },
 ];
+
+export const SnailPages = [
+  {
+    linkLabel: 'Adopt a Snail',
+    linkURL: '/snail-adoption',
+  },
+];

--- a/client/src/components/complex-components/NavBar/NavBar.tsx
+++ b/client/src/components/complex-components/NavBar/NavBar.tsx
@@ -4,7 +4,12 @@ import { FiChevronDown } from 'react-icons/fi';
 
 import { COLORS } from '../../../constants';
 import Search from '../SearchBar/Search';
-import { PrototypePages, SampleItems, SnailImageURL } from './NAV_BAR_LINKS';
+import {
+  PrototypePages,
+  SampleItems,
+  SnailImageURL,
+  SnailPages,
+} from './NAV_BAR_LINKS';
 import Logo from '../../../imgs/logo.png';
 
 const LinkStyle = css`
@@ -48,8 +53,13 @@ const LogoLinkWrapper = styled.a`
   height: 5rem;
 `;
 
-const NavLink = styled.a`
+const NavLink = styled.a<{ noLink?: boolean }>`
   ${LinkStyle}
+  ${(props) =>
+    props.noLink &&
+    css`
+      pointer-events: none;
+    `}
   display: flex;
   gap: 4px;
 `;
@@ -90,7 +100,7 @@ type DropDownProps = {
   /**
    * The url the link on the NavBar should go to
    */
-  linkURL: string;
+  linkURL?: string;
   /**
    * An array of elements to be rendered under the dropdown
    */
@@ -100,7 +110,7 @@ type DropDownProps = {
 const DropDownLink = ({ linkLabel, linkURL, dropDownItems }: DropDownProps) => {
   return (
     <DropDownWrapper>
-      <NavLink href={linkURL}>
+      <NavLink noLink>
         {linkLabel}
         <FiChevronDown role="presentation" size="2rem" />
       </NavLink>
@@ -125,21 +135,9 @@ export const NavBar = () => (
     </LogoLinkWrapper>
     <LinkWrapper>
       <NavLink href="/about">About</NavLink>
-      <DropDownLink
-        linkLabel="Prototype"
-        linkURL={SnailImageURL}
-        dropDownItems={PrototypePages}
-      />
-      <DropDownLink
-        linkLabel="Cluster"
-        linkURL={SnailImageURL}
-        dropDownItems={SampleItems}
-      />
-      <DropDownLink
-        linkLabel="Books"
-        linkURL={SnailImageURL}
-        dropDownItems={SampleItems}
-      />
+      <DropDownLink linkLabel="Prototype" dropDownItems={PrototypePages} />
+      <DropDownLink linkLabel="Cluster" dropDownItems={SampleItems} />
+      <DropDownLink linkLabel="Snails" dropDownItems={SnailPages} />
     </LinkWrapper>
     <SearchBarWrapper>
       <Search />

--- a/client/src/components/simple-components/ButtonsLinks.tsx
+++ b/client/src/components/simple-components/ButtonsLinks.tsx
@@ -42,33 +42,50 @@ const LargeCss = css`
   padding: 1.4rem 2rem;
 `;
 
+const DisabledCss = css`
+  border: 2px solid ${COLORS.GRAY_DARK};
+  background: none;
+  background-color: ${COLORS.GRAY_LIGHT};
+  color: ${COLORS.GRAY_MID};
+  pointer-events: none;
+  :hover {
+    background-color: ${COLORS.GRAY_LIGHT};
+  }
+`;
+
 // TODO: Parameterize sizes, roundness
-const SmallHalfRoundedButton = styled.button<{ color?: ColorType }>`
+const SmallHalfRoundedButton = styled.button<{ color?: ColorType, disabled?: boolean }>`
   ${ButtonCss}
   ${HalfRoundedCss}
     ${SmallCss}
 
     ${(props) => ColorCss(props.color)}
+
+  ${(props) => props.disabled && DisabledCss}
 `;
 
-const SmallRoundedButton = styled.button<{ color?: ColorType }>`
+const SmallRoundedButton = styled.button<{ color?: ColorType, disabled?: boolean }>`
   ${ButtonCss}
   ${RoundedCss}
     ${SmallCss}
 
     ${(props) => ColorCss(props.color)}
+
+  ${(props) => props.disabled && DisabledCss}
 `;
 
-const LargeRoundedButton = styled.button<{ color?: ColorType }>`
+const LargeRoundedButton = styled.button<{ color?: ColorType, disabled?: boolean }>`
   ${ButtonCss}
   ${RoundedCss}
     ${LargeCss}
 
     ${(props) => ColorCss(props.color)}
+
+  ${(props) => props.disabled && DisabledCss}
 `;
 
 // Looks like a button, but is a link
-const LargeRoundedLink = styled.a<{ color?: ColorType }>`
+const LargeRoundedLink = styled.a<{ color?: ColorType, disabled?: boolean }>`
   ${ButtonCss}
   ${RoundedCss}
     ${LargeCss}
@@ -77,6 +94,8 @@ const LargeRoundedLink = styled.a<{ color?: ColorType }>`
   text-decoration: none;
 
   ${(props) => ColorCss(props.color)}
+
+  ${(props) => props.disabled && DisabledCss}
 `;
 
 export {

--- a/client/src/components/simple-components/ButtonsLinks.tsx
+++ b/client/src/components/simple-components/ButtonsLinks.tsx
@@ -54,7 +54,10 @@ const DisabledCss = css`
 `;
 
 // TODO: Parameterize sizes, roundness
-const SmallHalfRoundedButton = styled.button<{ color?: ColorType, disabled?: boolean }>`
+const SmallHalfRoundedButton = styled.button<{
+  color?: ColorType;
+  disabled?: boolean;
+}>`
   ${ButtonCss}
   ${HalfRoundedCss}
     ${SmallCss}
@@ -64,7 +67,10 @@ const SmallHalfRoundedButton = styled.button<{ color?: ColorType, disabled?: boo
   ${(props) => props.disabled && DisabledCss}
 `;
 
-const SmallRoundedButton = styled.button<{ color?: ColorType, disabled?: boolean }>`
+const SmallRoundedButton = styled.button<{
+  color?: ColorType;
+  disabled?: boolean;
+}>`
   ${ButtonCss}
   ${RoundedCss}
     ${SmallCss}
@@ -74,7 +80,10 @@ const SmallRoundedButton = styled.button<{ color?: ColorType, disabled?: boolean
   ${(props) => props.disabled && DisabledCss}
 `;
 
-const LargeRoundedButton = styled.button<{ color?: ColorType, disabled?: boolean }>`
+const LargeRoundedButton = styled.button<{
+  color?: ColorType;
+  disabled?: boolean;
+}>`
   ${ButtonCss}
   ${RoundedCss}
     ${LargeCss}
@@ -85,7 +94,7 @@ const LargeRoundedButton = styled.button<{ color?: ColorType, disabled?: boolean
 `;
 
 // Looks like a button, but is a link
-const LargeRoundedLink = styled.a<{ color?: ColorType, disabled?: boolean }>`
+const LargeRoundedLink = styled.a<{ color?: ColorType; disabled?: boolean }>`
   ${ButtonCss}
   ${RoundedCss}
     ${LargeCss}

--- a/client/src/constants/Colors.tsx
+++ b/client/src/constants/Colors.tsx
@@ -6,6 +6,9 @@ export const COLORS = {
   PURPLE_MID: '#43239D',
   PURPLE_DARK: '#21033f',
   WHITE: '#F5F5F5',
+  GRAY_LIGHT: '#cccccc',
+  GRAY_MID: '#555555',
+  GRAY_DARK: '#999999',
   BLACK: '#060606',
 };
 

--- a/client/src/pages/CreateGoal.tsx
+++ b/client/src/pages/CreateGoal.tsx
@@ -132,38 +132,38 @@ function CreateGoal() {
         <GoalCard>
           <H1>Create a Goal</H1>
           <GoalInfoWrapper>
-          <DeadlineWrapper>
-            <Label htmlFor="deadline-datepicker">Goal Deadline</Label>
-            <DatePicker // TODO: Look into console error
-              name="deadline-datepicker"
-              className="datepicker"
-              selected={startDate}
-              onChange={(newDate) => {
-                if (newDate) {
+            <DeadlineWrapper>
+              <Label htmlFor="deadline-datepicker">Goal Deadline</Label>
+              <DatePicker // TODO: Look into console error
+                name="deadline-datepicker"
+                className="datepicker"
+                selected={startDate}
+                onChange={(newDate) => {
+                  if (newDate) {
                     const today = new Date();
-                    if (newDate < today) { // If the new date is in the past, it's invalid
-                        console.log("This date is in the past!");
+                    if (newDate < today) {
+                      // If the new date is in the past, it's invalid
+                      console.log('This date is in the past!');
+                    } else {
+                      setStartDate(newDate);
+                      setNumDays(NumberOfDaysUntilDate(newDate));
                     }
-                    else {
-                        setStartDate(newDate);
-                        setNumDays(NumberOfDaysUntilDate(newDate));
-                    }
-                }
-              }}
-            />
-          </DeadlineWrapper>
-          <P>
-            With this deadline, you will have <b>{numDays} days</b> to complete
-            your goal.
-          </P>
-          <P>
-            On average, you will need to read <b>{numPages / numDays} pages</b>{' '}
-            per day.
-          </P>
+                  }
+                }}
+              />
+            </DeadlineWrapper>
+            <P>
+              With this deadline, you will have <b>{numDays} days</b> to
+              complete your goal.
+            </P>
+            <P>
+              On average, you will need to read{' '}
+              <b>{numPages / numDays} pages</b> per day.
+            </P>
           </GoalInfoWrapper>
           <NotesWrapper>
-          <Label htmlFor="goal-notes">Notes (Optional)</Label>
-          <textarea name="goal-notes" />
+            <Label htmlFor="goal-notes">Notes (Optional)</Label>
+            <textarea name="goal-notes" />
           </NotesWrapper>
           <SnailSection>
             <img

--- a/client/src/pages/SnailAdoption.tsx
+++ b/client/src/pages/SnailAdoption.tsx
@@ -66,8 +66,10 @@ const InputWrapper = styled.div`
  * - Close modal on escape press
  */
 function SnailAdoption() {
-  const [isModalOpen, toggleIsModalOpen] = useState(false);
   const [snailColor, setSnailColor] = useState('blue');
+  const [snailName, setSnailName] = useState('');
+  const [isModalOpen, toggleIsModalOpen] = useState(false);
+  const [allowContinue, setAllowContinue] = useState(false); // Used to ensure user names snail before continuing
   ReactModal.setAppElement('*');
 
   return (
@@ -112,13 +114,17 @@ function SnailAdoption() {
               <H2>Name Your Snail!</H2>
               <InputWrapper>
                 <Label htmlFor="snail-name">Name:</Label>
-                <ThickInput name="snail-name" />
+                <ThickInput name="snail-name" value={snailName} onInput={(event) => {
+                  const element = event.currentTarget as HTMLInputElement;
+                  setSnailName(element.value);
+                  setAllowContinue(snailName !== '');
+                }}/>
               </InputWrapper>
               <P>
                 <b>Warning:</b> You're responsible for your snail's wellbeing.
                 By continuing, you accept responsibility for this snail's life.
               </P>
-              <LargeRoundedLink href="/" disabled>Adopt Snail</LargeRoundedLink>
+              <LargeRoundedLink href="/" disabled={!allowContinue}>Adopt Snail</LargeRoundedLink>
             </RightModalContentWrapper>
           </ModalContentWrapper>
         </ReactModal>

--- a/client/src/pages/SnailAdoption.tsx
+++ b/client/src/pages/SnailAdoption.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import ReactModal from 'react-modal';
+import OWServiceProvider from '../OuterWhorldServiceProvider';
 import {
   CloseButton,
   H2,
   Label,
   LargeRoundedButton,
-  LargeRoundedLink,
   P,
   PageWrapper,
   SnailSelectCard,
@@ -66,11 +67,24 @@ const InputWrapper = styled.div`
  * - Close modal on escape press
  */
 function SnailAdoption() {
+  const userName = 'andrei'; // TODO: Get user's username when login implemented
   const [snailColor, setSnailColor] = useState('blue');
   const [snailName, setSnailName] = useState('');
   const [isModalOpen, toggleIsModalOpen] = useState(false);
   const [allowContinue, setAllowContinue] = useState(false); // Used to ensure user names snail before continuing
+  const navigate = useNavigate(); // Used to redirect after snail is adopted
   ReactModal.setAppElement('*');
+
+  const handleSubmit = async (e: any) => {
+    e.preventDefault();
+    const create = await OWServiceProvider.createSnail(
+      userName,
+      snailName,
+      snailColor
+    );
+    console.log(create);
+    navigate('/');
+  };
 
   return (
     <PageWrapper pageTitle="Adopt A Snail" header="Adopt A Snail">
@@ -114,17 +128,26 @@ function SnailAdoption() {
               <H2>Name Your Snail!</H2>
               <InputWrapper>
                 <Label htmlFor="snail-name">Name:</Label>
-                <ThickInput name="snail-name" value={snailName} onInput={(event) => {
-                  const element = event.currentTarget as HTMLInputElement;
-                  setSnailName(element.value);
-                  setAllowContinue(snailName !== '');
-                }}/>
+                <ThickInput
+                  name="snail-name"
+                  value={snailName}
+                  onInput={(event) => {
+                    const element = event.currentTarget as HTMLInputElement;
+                    setSnailName(element.value);
+                    setAllowContinue(snailName !== '');
+                  }}
+                />
               </InputWrapper>
               <P>
                 <b>Warning:</b> You're responsible for your snail's wellbeing.
                 By continuing, you accept responsibility for this snail's life.
               </P>
-              <LargeRoundedLink href="/" disabled={!allowContinue}>Adopt Snail</LargeRoundedLink>
+              <LargeRoundedButton
+                disabled={!allowContinue}
+                onClick={handleSubmit}
+              >
+                Adopt Snail
+              </LargeRoundedButton>
             </RightModalContentWrapper>
           </ModalContentWrapper>
         </ReactModal>

--- a/client/src/pages/SnailAdoption.tsx
+++ b/client/src/pages/SnailAdoption.tsx
@@ -118,7 +118,7 @@ function SnailAdoption() {
                 <b>Warning:</b> You're responsible for your snail's wellbeing.
                 By continuing, you accept responsibility for this snail's life.
               </P>
-              <LargeRoundedLink href="/">Adopt Snail</LargeRoundedLink>
+              <LargeRoundedLink href="/" disabled>Adopt Snail</LargeRoundedLink>
             </RightModalContentWrapper>
           </ModalContentWrapper>
         </ReactModal>

--- a/client/src/utils/DateUtils.tsx
+++ b/client/src/utils/DateUtils.tsx
@@ -1,7 +1,7 @@
 function NumberOfDaysUntilDate(date: Date) {
-    const today = new Date();
-    let timeDiff = date.getTime() -  today.getTime();
-    return(Math.floor(timeDiff / (1000 * 3600 * 24)) + 1); // Add 1; You can read the day it's due, too
+  const today = new Date();
+  let timeDiff = date.getTime() - today.getTime();
+  return Math.floor(timeDiff / (1000 * 3600 * 24)) + 1; // Add 1; You can read the day it's due, too
 }
 
 export { NumberOfDaysUntilDate };


### PR DESCRIPTION
- Connected snail page to API - now saves the user's snail
- Updated NavBar to remove link styling for top of dropdown
- Updated NavBar to have snails dropdown

Considerations for the Future:
- The Adopt a Snail page should only be accessed when the user doesn't yet have a snail. Ideally, this should be immediately after login. Once we have login implemented we need to go back to this page and protect it so that the page cannot be accessed after the first login + snail adoption
- Also, since we don't want a user to go to other parts of the website before adopting a snail, we should remove the navbar from the pre-login homepage and the Adopt a Snail page