### PR TITLE
Hotfixes

### DIFF
--- a/client/src/components/complex-components/Goals/GoalCard.tsx
+++ b/client/src/components/complex-components/Goals/GoalCard.tsx
@@ -47,13 +47,15 @@ const ResultWrapper = styled.div`
 
 //TODO: have cover wrapper adjust to image size
 const CoverWrapper = styled.div`
+  display: flex;
+  flex-flow: wrap;
+  align-items: center;
+  justify-content: center;
   width: 15rem;
-  height: 24rem;
   background-color: ${COLORS.PURPLE_DARK};
   border: 3px solid ${COLORS.PURPLE_MID};
   overflow-y: hidden;
   max-width-inline: 100%;
-  object-fit: scale-down;
   margin-block-end: 1.5rem;
   margin-block-start: 0.5rem;
 `;
@@ -76,7 +78,7 @@ export const GoalCard = ({
     <ResultWrapper className="book-card">
       <CoverWrapper>
         <img
-          style={{ maxWidth: '100%', height: '100%' }}
+          style={{ width: '100%' }}
           src={bookCover}
           alt={bookTitle + ' book cover'}
         />

--- a/client/src/pages/CreateCluster.tsx
+++ b/client/src/pages/CreateCluster.tsx
@@ -142,7 +142,7 @@ function CreateCluster() {
       userName,
       visibility
     );
-    navigate('view-clusters');
+    navigate('/view-clusters');
   };
 
   return (

--- a/client/src/pages/ViewGoals.tsx
+++ b/client/src/pages/ViewGoals.tsx
@@ -102,7 +102,6 @@ function ViewGoals(this: any) {
   let temp: any;
   const goalID: any = [];
   let noDuplicatesID: number[];
-  const goalArray: any[] = [];
   let snailInfo: any;
   useEffect(() => {
     const loadData = async () => {
@@ -111,11 +110,11 @@ function ViewGoals(this: any) {
       setSnailColor(snailInfo.color);
       // setSnailHealth(snailInfo.health); // TODO
       setSnailImage(GetSnailImg(snailInfo.color, snailHealth));
-      //TODO: Set snail health
+      
+      const goalArray: any[] = [];
       temp = await OWServiceProvider.getAllGoals(username);
-
       setAllGoals(temp);
-      const getID = temp.map((x: any) => {
+      temp.map((x: any) => {
         var y: number = +x.goal_id;
         goalID.push(y);
       });
@@ -274,9 +273,9 @@ function ViewGoals(this: any) {
         {snailHealth !== 0 && ( // Don't show Goals if snail is dead
           <GoalsCard>
             <H2>Active Goals</H2>
-            <GoalsWrapper $hasGoals={allGoals.length !== 0}>
+            <GoalsWrapper $hasGoals={indGoals.length !== 0}>
               {goal}
-              {allGoals.length === 0 && (
+              {indGoals.length === 0 && (
                 <>
                   <H3>You have no goals!</H3>
                   <P>
@@ -289,7 +288,7 @@ function ViewGoals(this: any) {
                     <b>stay at its current health</b> if you don't have any
                     goals set.
                   </P>
-                  <LargeRoundedButton>Go to Clusters</LargeRoundedButton>
+                  <LargeRoundedButton onClick={() => {navigate('/view-clusters')}}>Go to Clusters</LargeRoundedButton>
                 </>
               )}
             </GoalsWrapper>


### PR DESCRIPTION
1. On /view-goals, goals are no longer duplicated
2. The redirect from /create-cluster to /view-clusters is fixed
3. Fixed a bug where goal book covers were not displaying at the correct size and were being stretched out
4. Correctly linked /view-goals button to /view-clusters when there are no active goals