### PR TITLE
Bug Fixes Graveyard and updateSnail

### DIFF
--- a/client/src/OuterWhorldServiceProvider.ts
+++ b/client/src/OuterWhorldServiceProvider.ts
@@ -232,6 +232,20 @@ class OuterWhorldServiceProvider {
     return data;
   }
 
+    /*
+  @param userName
+  @returns Snail object
+  */
+  async getAllSnails(userName: string) {
+    const res = await fetch(`/api/snails/all/?userName=${userName}`);
+    const data = await res.json();
+
+    if (res.status !== 200) {
+      return null;
+    }
+    return data;
+  }
+
   /*
   @param userName
   @param snailName - if keeping the same, pass in existing name

--- a/client/src/OuterWhorldServiceProvider.ts
+++ b/client/src/OuterWhorldServiceProvider.ts
@@ -234,7 +234,7 @@ class OuterWhorldServiceProvider {
 
     /*
   @param userName
-  @returns Snail object
+  @returns Array of snail objects
   */
   async getAllSnails(userName: string) {
     const res = await fetch(`/api/snails/all/?userName=${userName}`);

--- a/client/src/pages/GraveAdoption.tsx
+++ b/client/src/pages/GraveAdoption.tsx
@@ -104,15 +104,21 @@ function GraveAdoption() {
   const [graveType, setGraveType] = useState(0);
 
   const handleChange = async () => {
-    const snail = await OWServiceProvider.getSnailInfo(username);
-    const graveSelection = await OWServiceProvider.createGrave(
-      snail.name,
-      username,
-      selected,
-      graveType
-    );
-    console.log(graveSelection);
-    navigate('/graveyard', { state: { selected } });
+    const snails = await OWServiceProvider.getAllSnails(username);
+    for (const snail of snails) {
+      if (snail.health <= 0 && snail.date_died === 'null') {
+        console.log(snail);
+        const graveSelection = await OWServiceProvider.createGrave(
+          snail.name,
+          username,
+          selected,
+          graveType
+        );
+        console.log(graveSelection);
+        navigate('/graveyard', { state: { selected } });
+        break;
+      }
+    }
   };
 
   const handleGraveOne = () => {

--- a/client/src/pages/GraveAdoption.tsx
+++ b/client/src/pages/GraveAdoption.tsx
@@ -107,14 +107,12 @@ function GraveAdoption() {
     const snails = await OWServiceProvider.getAllSnails(username);
     for (const snail of snails) {
       if (snail.health <= 0 && snail.date_died === 'null') {
-        console.log(snail);
         const graveSelection = await OWServiceProvider.createGrave(
           snail.name,
           username,
           selected,
           graveType
         );
-        console.log(graveSelection);
         navigate('/graveyard', { state: { selected } });
         break;
       }

--- a/client/src/pages/Graveyard.tsx
+++ b/client/src/pages/Graveyard.tsx
@@ -130,7 +130,7 @@ function Graveyard() {
       setGrave([...graveArray]);
     };
     loadData();
-  });
+  }, []);
   const temp = grave.map((x: any, i: any) => {
     return (
       <div key={i}>

--- a/client/src/pages/UpdateGoal.tsx
+++ b/client/src/pages/UpdateGoal.tsx
@@ -177,6 +177,8 @@ function UpdateGoal() {
   const [eatingSnailImage, setEatingSnailImage] = useState('');
   const [snailHealth, setSnailHealth] = useState(3);
   const [foodColor, setFoodColor] = useState('');
+  const [goalsCompleted, setGoalsCompleted] = useState(0);
+  const [goalsFailed, setGoalsFailed] = useState(0);
 
   const location = useLocation();
 
@@ -199,6 +201,8 @@ function UpdateGoal() {
       setSnailHealth(snailInfo.health);
       setSnailImage(GetSnailImg(snailColor, snailHealth));
       setEatingSnailImage(GetEatingSnailImg(snailColor, foodColor));
+      setGoalsCompleted(snailInfo.goals_completed);
+      setGoalsFailed(snailInfo.goals_failed);
     };
     loadData();
   });
@@ -277,7 +281,9 @@ function UpdateGoal() {
                   snailColor,
                   snailHealth,
                   notes,
-                  numPagesTotal
+                  numPagesTotal,
+                  goalsCompleted,
+                  goalsFailed
                 );
               }}
             >

--- a/client/src/utils/FoodUtils.tsx
+++ b/client/src/utils/FoodUtils.tsx
@@ -37,6 +37,8 @@ async function ApplyFoodAffect(
   snailName: string,
   snailColor: string,
   snailHealth: number,
+  goals_completed: number,
+  goals_failed: number,
   notes: any,
   newPagesRead: number
 ) {
@@ -57,7 +59,9 @@ async function ApplyFoodAffect(
           username,
           snailName,
           snailColor,
-          newSnailHealth
+          newSnailHealth,
+          goals_completed,
+          goals_failed
         );
       }
       return;

--- a/client/src/utils/SnailHealthUtils.tsx
+++ b/client/src/utils/SnailHealthUtils.tsx
@@ -1,60 +1,78 @@
 import OWServiceProvider from '../OuterWhorldServiceProvider';
 
 const updateSnailStatus = async (username: string) => {
-  const snailInfo = await OWServiceProvider.getSnailInfo(username);
+  const snailInfo = await OWServiceProvider.getAllSnails(username);
 
-  console.log(snailInfo);
-
-  // Case 1 - Snail does not exist
-  if (snailInfo === null) {
+  // Case 1 - User has no snails, first time login
+  if (snailInfo.length === 0) {
     return 'dne';
   }
 
-  // Case 2 - Snail exists, but is dead
-  let snailHealth = snailInfo.health;
+  let needsnewSnail = true;
 
-  if (snailHealth <= 0) {
-    // First, see if they're dead already
-    return 'dead';
-  } else {
-    // See if they die today
-    const today = new Date();
-    const allGoals = await OWServiceProvider.getAllGoals(username);
-    const goalID: any = [];
-    let noDuplicatesID: number[];
-    const goalArray: any[] = [];
+  for (const snail of snailInfo) {
+    // Case 2 - Snail exists, but is dead
 
-    // From ViewGoals - Erin's work
-    allGoals.map((x: any) => {
-      var y: number = +x.goal_id;
-      goalID.push(y);
-    });
-    //above map out puts duplicate of every goal_id
-    //noDuplicatesID removes these
-    noDuplicatesID = Array.from(new Set(goalID));
-    for (const i of noDuplicatesID) {
-      goalArray.push(await OWServiceProvider.getGoal(username, i));
+    let snailHealth = snail.health;
+    const { date_died } = snail;
+
+    if (date_died === 'null') {
+      needsnewSnail = false;
     }
 
-    allGoals.map((goal: any) => {
-      const dueDate = new Date(goal.deadline);
-      if (dueDate < today) {
-        // If due date passed
-        snailHealth--;
-        if (snailHealth <= 0) {
-          return 'dead';
-        }
-      }
-    });
+    // Snail is dead but doesn't have gravestone yet, navigate to graveyard
+    if (snailHealth <= 0 && date_died === 'null') {
+      return 'dead';
+    } else if (snailHealth <= 0 && date_died !== 'null') {
+      continue;
+    } else {
+      //See if snail dies today
+      const today = new Date();
+      const allGoals = await OWServiceProvider.getAllGoals(username);
+      const goalID: any = [];
+      let noDuplicatesID: number[];
+      const goalArray: any[] = [];
 
-    // Case 3 - Snail is still alive
-    await OWServiceProvider.updateSnailInfo(
-      username,
-      snailInfo.name,
-      snailInfo.color,
-      snailHealth
-    ); // Save updated snail health
-    return 'alive';
+      // From ViewGoals - Erin's work
+      allGoals.map((x: any) => {
+        var y: number = +x.goal_id;
+        goalID.push(y);
+      });
+      //above map out puts duplicate of every goal_id
+      //noDuplicatesID removes these
+      noDuplicatesID = Array.from(new Set(goalID));
+      for (const i of noDuplicatesID) {
+        goalArray.push(await OWServiceProvider.getGoal(username, i));
+      }
+
+      allGoals.map((goal: any) => {
+        const dueDate = new Date(goal.deadline);
+        if (dueDate < today) {
+          // If due date passed
+          snailHealth--;
+        }
+      });
+
+      const res = await OWServiceProvider.updateSnailInfo(
+        username,
+        snail.name,
+        snail.color,
+        snailHealth,
+        snail.goals_completed,
+        snail.goals_failed
+      );
+
+      if (snailHealth <= 0) {
+        return 'dead';
+      }
+
+      // Case 3 - Snail is still alive
+      return 'alive';
+    }
+  }
+
+  if (needsnewSnail) {
+    return 'dne';
   }
 };
 

--- a/client/src/utils/SnailHealthUtils.tsx
+++ b/client/src/utils/SnailHealthUtils.tsx
@@ -53,7 +53,7 @@ const updateSnailStatus = async (username: string) => {
         }
       });
 
-      const res = await OWServiceProvider.updateSnailInfo(
+      await OWServiceProvider.updateSnailInfo(
         username,
         snail.name,
         snail.color,

--- a/server/src/routes/snailRoutes.ts
+++ b/server/src/routes/snailRoutes.ts
@@ -5,11 +5,14 @@ import {
 	updateSnail,
 	createSnail,
 	deleteSnail,
+	getAllSnails,
 } from "../controllers/snailController";
 
 const snailRouter = express.Router();
 
 snailRouter.get("/", getSnail);
+
+snailRouter.get("/all", getAllSnails);
 
 snailRouter.put("/", updateSnail);
 


### PR DESCRIPTION
- fixed bug in updateSnail that updated incorrect snail's info
- changed updateSnailStatus logic to check if user has dead snail that
  needs to go to graveyard
- add getAllSnails endpoint that gets ALL user snails (dead or alive).
  getSnailInfo will now be used to only get current alive snail for
  user (shouldn't require any refactoring for existing code).