### PR TITLE
Graveyard workflow bug fixes

### DIFF
--- a/client/src/pages/AllSnails.tsx
+++ b/client/src/pages/AllSnails.tsx
@@ -219,16 +219,20 @@ function AllSnails() {
     snailHealth: number
   ) => {
     const currentSnail = await OWServiceProvider.getSnailInfo(username);
-    const updateCurrent = await OWServiceProvider.updateSnailInfo(
-      username,
-      currentSnail.name,
-      currentSnail.color,
-      currentSnail.health,
-      currentSnail.goals_completed,
-      currentSnail.goals_failed,
-      currentSnail.accessories,
-      false
-    );
+
+    if (currentSnail) {
+      const updateCurrent = await OWServiceProvider.updateSnailInfo(
+        username,
+        currentSnail.name,
+        currentSnail.color,
+        currentSnail.health,
+        currentSnail.goals_completed,
+        currentSnail.goals_failed,
+        currentSnail.accessories,
+        false
+      );
+    }
+
     const newCurrent = await OWServiceProvider.updateSnailInfo(
       username,
       name,

--- a/client/src/pages/GraveAdoption.tsx
+++ b/client/src/pages/GraveAdoption.tsx
@@ -115,7 +115,7 @@ function GraveAdoption() {
   const handleChange = async () => {
     const snails = await OWServiceProvider.getAllSnails(username);
     for (const snail of snails) {
-      if (snail.health <= 0 && snail.date_died === 'null') {
+      if (snail.health <= 0 && (snail.date_died == null || snail.date_died == 'null') && snail.is_active) {
         const date = new Date();
         const dateString = date.toDateString();
         const updateSnail = await OWServiceProvider.updateSnailInfo(

--- a/client/src/pages/Graveyard.tsx
+++ b/client/src/pages/Graveyard.tsx
@@ -288,7 +288,7 @@ function Graveyard() {
           <div key={i}>
             <ScrollableDiv>
               <AllGraveWrapper>
-                {x.graveInfo.map((a: any, b: any) => {
+                {x.graveInfo.reverse().map((a: any, b: any) => {
                   return (
                     <div key={b}>
                       <GraveWrapper

--- a/client/src/utils/SnailHealthUtils.tsx
+++ b/client/src/utils/SnailHealthUtils.tsx
@@ -25,9 +25,10 @@ const updateSnailStatus = async (username: string) => {
       hasActiveSnail = true;
 
       // Snail is dead but doesn't have gravestone yet, navigate to graveyard
-      if (snailHealth <= 0 && date_died === 'null') {
+      if (snailHealth <= 0 && (date_died == null || date_died == 'null')) {
+        console.log("in");
         return 'dead';
-      } else if (snailHealth <= 0 && date_died !== 'null') {
+      } else if (snailHealth <= 0 && (date_died != null || date_died != 'null')) {
         continue;
       } else {
         //See if snail dies today


### PR DESCRIPTION
- in the db sometimes null is being stored as the type null or string 'null', so i added checks for both
- improved user flow by letting users choose an active snail after reviving if they don't currently have an active snail